### PR TITLE
Add sample param to Standard Deviation and Coefficient of Variation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,21 @@ nosetests --with-doctest
 
 #### Measures of dispersion
 
-| Function                                   | Example                                      |
-|--------------------------------------------|----------------------------------------------|
-| [Sample and population variance][variance] | `variance([1, 2, 3], sample = True)`         |
-| [Standard deviation][sd]                   | `standard_deviation([1, 2, 3])`              |
-| [Coefficient of variation][cv]             | `coefficient_of_variation([1, 2, 3])`        |
-| [Interquartile range][]                    | `interquartile_range([1, 3, 5, 7])`          |
-| [Sum of Nth power deviations][sumndevs]    | `sum_nth_power_deviations([-1, 0, 2, 4], 3)` |
-| [Standard scores (z-scores)][zscores]      | `z_scores([-2, -1, 0, 1, 2])`                |
+| Function                                              | Example                                               |
+|-------------------------------------------------------|-------------------------------------------------------|
+| [Sample and population variance][variance]            | `variance([1, 2, 3], sample = True)`                  |
+| [Sample and population Standard deviation][sd]        | `standard_deviation([1, 2, 3], sample = True)`        |
+| [Sample and population Coefficient of variation][cv]  | `coefficient_of_variation([1, 2, 3], sample = True)`  |
+| [Interquartile range][]                               | `interquartile_range([1, 3, 5, 7])`                   |
+| [Sum of Nth power deviations][sumndevs]               | `sum_nth_power_deviations([-1, 0, 2, 4], 3)`          |
+| [Standard scores (z-scores)][zscores]                 | `z_scores([-2, -1, 0, 1, 2])`                         |
 
 [variance]: http://simplestatistics.readthedocs.io/en/latest/#variance
 [sd]: http://simplestatistics.readthedocs.io/en/latest/#standard-deviation
-[cv]: http://simplestatistics.readthedocs.io/en/latest/#coefficient_of_variation
+[cv]: http://simplestatistics.readthedocs.io/en/latest/#coefficient-of-variation
 [Interquartile range]: http://simplestatistics.readthedocs.io/en/latest/#interquartile-range
 [sumndevs]: http://simplestatistics.readthedocs.io/en/latest/#sum-of-nth-power-deviations
-[zscores]: http://simplestatistics.readthedocs.io/en/latest/#standard-scores-z-scores 
+[zscores]: http://simplestatistics.readthedocs.io/en/latest/#standard-scores-z-scores
 
 #### Linear regression
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ nosetests --with-doctest
 
 #### Measures of dispersion
 
-| Function                                              | Example                                               |
-|-------------------------------------------------------|-------------------------------------------------------|
-| [Sample and population variance][variance]            | `variance([1, 2, 3], sample = True)`                  |
-| [Sample and population Standard deviation][sd]        | `standard_deviation([1, 2, 3], sample = True)`        |
-| [Sample and population Coefficient of variation][cv]  | `coefficient_of_variation([1, 2, 3], sample = True)`  |
-| [Interquartile range][]                               | `interquartile_range([1, 3, 5, 7])`                   |
-| [Sum of Nth power deviations][sumndevs]               | `sum_nth_power_deviations([-1, 0, 2, 4], 3)`          |
-| [Standard scores (z-scores)][zscores]                 | `z_scores([-2, -1, 0, 1, 2])`                         |
+| Function                                                    | Example                                               |
+|-------------------------------------------------------------|-------------------------------------------------------|
+| [Sample and population variance][variance]                  | `variance([1, 2, 3], sample = True)`                  |
+| [Sample and population Standard deviation][sd]              | `standard_deviation([1, 2, 3], sample = True)`        |
+| [Sample and population Coefficient of variation][cv]        | `coefficient_of_variation([1, 2, 3], sample = True)`  |
+| [Interquartile range][]                                     | `interquartile_range([1, 3, 5, 7])`                   |
+| [Sum of Nth power deviations][sumndevs]                     | `sum_nth_power_deviations([-1, 0, 2, 4], 3)`          |
+| [Sample and population Standard scores (z-scores)][zscores] | `z_scores([-2, -1, 0, 1, 2], sample = True)`          |
 
 [variance]: http://simplestatistics.readthedocs.io/en/latest/#variance
 [sd]: http://simplestatistics.readthedocs.io/en/latest/#standard-deviation

--- a/simplestatistics/statistics/coefficient_of_variation.py
+++ b/simplestatistics/statistics/coefficient_of_variation.py
@@ -14,7 +14,7 @@ def coefficient_of_variation(data, sample = True):
     Examples:
         >>> coefficient_of_variation([1, 2, 3])
         0.5
-        >>> ss.coefficient_of_variation([1, 2, 3], False)
+        >>> coefficient_of_variation([1, 2, 3], False)
         0.408248290463863
         >>> coefficient_of_variation([1, 2, 3, 4])
         0.5163977794943222

--- a/simplestatistics/statistics/coefficient_of_variation.py
+++ b/simplestatistics/statistics/coefficient_of_variation.py
@@ -9,6 +9,9 @@ def coefficient_of_variation(data, sample = True):
 
     Args:
         data: A list of numerical objects.
+        sample: A boolean value. If True, calculates coefficient of variation for
+          sample. If False, calculates coefficient of variation for population.
+
     Returns:
         A float object.
     Examples:

--- a/simplestatistics/statistics/coefficient_of_variation.py
+++ b/simplestatistics/statistics/coefficient_of_variation.py
@@ -1,9 +1,10 @@
 from .standard_deviation import standard_deviation
 from .mean import mean
 
-def coefficient_of_variation(data):
+def coefficient_of_variation(data, sample = True):
     """
-    The `coefficient_of_variation`_ is the ratio of the standard deviation to the mean
+    The `coefficient of variation`_ is the ratio of the standard deviation to the mean.
+
     .. _`coefficient of variation`: https://en.wikipedia.org/wiki/Coefficient_of_variation
 
     Args:
@@ -13,10 +14,11 @@ def coefficient_of_variation(data):
     Examples:
         >>> coefficient_of_variation([1, 2, 3])
         0.5
+        >>> ss.coefficient_of_variation([1, 2, 3], False)
+        0.408248290463863
         >>> coefficient_of_variation([1, 2, 3, 4])
         0.5163977794943222
         >>> coefficient_of_variation([-1, 0, 1, 2, 3, 4])
         1.247219128924647
     """
-    return standard_deviation(data) / mean(data)
-    
+    return standard_deviation(data, sample) / mean(data)

--- a/simplestatistics/statistics/standard_deviation.py
+++ b/simplestatistics/statistics/standard_deviation.py
@@ -1,7 +1,7 @@
 import math
 from .variance import variance
 
-def standard_deviation(data):
+def standard_deviation(data, sample = True):
     """
     The `standard deviation`_ is the square root of variance_ (the sum of squared deviations
     from the mean).
@@ -25,6 +25,8 @@ def standard_deviation(data):
 
     Args:
         data: A list of numerical objects.
+        sample: A boolean value. If True, calculates standard deviation for
+          sample. If False, calculates standard deviation for population.
 
     Returns:
         A float object.
@@ -33,11 +35,11 @@ def standard_deviation(data):
 
         >>> standard_deviation([1, 2, 3])
         1.0
+        >>> ss.standard_deviation([1, 2, 3], False)
+        0.816496580927726
         >>> standard_deviation([1, 2, 3, 4])
         1.2909944487358056
         >>> standard_deviation([-1, 0, 1, 2, 3, 4])
         1.8708286933869707
     """
-    return math.sqrt(variance(data))
-
-
+    return math.sqrt(variance(data, sample))

--- a/simplestatistics/statistics/standard_deviation.py
+++ b/simplestatistics/statistics/standard_deviation.py
@@ -35,7 +35,7 @@ def standard_deviation(data, sample = True):
 
         >>> standard_deviation([1, 2, 3])
         1.0
-        >>> ss.standard_deviation([1, 2, 3], False)
+        >>> standard_deviation([1, 2, 3], False)
         0.816496580927726
         >>> standard_deviation([1, 2, 3, 4])
         1.2909944487358056

--- a/simplestatistics/statistics/z_scores.py
+++ b/simplestatistics/statistics/z_scores.py
@@ -2,7 +2,7 @@ from .mean import mean
 from .decimalize import decimalize
 from .standard_deviation import standard_deviation
 
-def z_scores(data):
+def z_scores(data, sample = True):
     """
     Standardizing a variable or set of data is transforming the data such that it
     has a mean of 0 and standard deviation of 1.
@@ -20,6 +20,8 @@ def z_scores(data):
 
     Args:
         data: A list of numerical objects.
+        sample: A boolean value. If True, calculates z scores for
+          sample. If False, calculates z scores for population.
 
     Returns:
         A list of float objects.
@@ -27,8 +29,12 @@ def z_scores(data):
     Examples:
         >>> z_scores([-2, -1, 0, 1, 2])
         [1.2649110640673518, 0.6324555320336759, 0.0, -0.6324555320336759, -1.2649110640673518]
+        >>> z_scores([-2, -1, 0, 1, 2], False)
+        [1.414213562373095, 0.7071067811865475, 0.0, -0.7071067811865475, -1.414213562373095]
         >>> z_scores([1, 2])
         [0.7071067811865475, -0.7071067811865475]
+        >>> z_scores([1, 2], False)
+        [1.0, -1.0]
         >>> z_scores([90]) # a z score for one value is not defined
         >>> z_scores(4) # a z score for one value is not defined
     """
@@ -41,7 +47,7 @@ def z_scores(data):
             return(None)
 
         mean_of_data = decimalize(mean(data))
-        sd_of_data = decimalize(standard_deviation(data))
+        sd_of_data = decimalize(standard_deviation(data, sample))
 
         z_scores = [float((mean_of_data - ii) / sd_of_data) for ii in data]
         return(z_scores)


### PR DESCRIPTION
Boolean param _sample_ in `variance()` makes it possible to choose between Sample or Population. Although `standard_deviation()` and `coefficient_of_variation()` methods calls `standard_deviation()` to calculate the final result, neither of them passed this param. As _sample_ is the default param in `variance()`, there was no way to calculate Standard Deviation or Coefficient of Variation for a population dataset.

Changes made in this pull request adds _sample_ param to both. (with default value set to `True`)
